### PR TITLE
Fixes ambiguous type error with newer RealmSwift

### DIFF
--- a/CardinalKit/CardinalKit/Source/Components/HealthKit/Models/HealthKitData.swift
+++ b/CardinalKit/CardinalKit/Source/Components/HealthKit/Models/HealthKitData.swift
@@ -35,11 +35,11 @@ class HealthKitData: Object, Mappable, Codable {
     
     @objc dynamic var passiveWhenCollected : Bool = false
     
-    required convenience init?(map: Map) {
+    required convenience init?(map: ObjectMapper.Map) {
         self.init()
     }
     
-    func mapping(map: Map) {
+    func mapping(map: ObjectMapper.Map) {
         startDate <- map["start_date"]
         endDate <- map["end_date"]
         date <- map["date"]


### PR DESCRIPTION
Fixes ambiguous type error that occurs with newer versions of RealmSwift, which prevents the Realm dependencies in this version from being upgraded.