### PR TITLE
Disables HealthKit background sync

### DIFF
--- a/CardinalKit/CardinalKit-Example/CardinalKit/AppDelegate+CardinalKit.swift
+++ b/CardinalKit/CardinalKit-Example/CardinalKit/AppDelegate+CardinalKit.swift
@@ -29,18 +29,18 @@ extension AppDelegate {
         CKApp.configure(options)
         
         // (3) if we have already logged in
-        if CKStudyUser.shared.isLoggedIn {
+        if CKStudyUser.shared.currentUser != nil {
             CKStudyUser.shared.save()
-            
+
+            // ** HealthKit background sync is disabled currently **
+            //
             // (4) then start the requested HK data collection (if any).
-            let manager = CKHealthKitManager.shared
-            manager.getHealthAuthorization { (success, error) in
-                if let error = error {
-                    print(error)
-                }
-            }
+            // let manager = CKHealthKitManager.shared
+            // manager.getHealthAuthorization { (success, error) in
+            //    if let error = error {
+            //        print(error)
+            //    }
+            // }
         }
-        CKStudyUser.shared.save()
     }
-    
 }

--- a/CardinalKit/CardinalKit-Example/CardinalKit/Components/Onboarding/OnboardingViewController.swift
+++ b/CardinalKit/CardinalKit-Example/CardinalKit/Components/Onboarding/OnboardingViewController.swift
@@ -113,7 +113,7 @@ struct OnboardingViewController: UIViewControllerRepresentable {
         let introSteps = [ORKStep]()
         
         // and steps regarding login / security
-        let emailVerificationSteps = loginSteps + [passcodeStep, healthDataStep]
+        let emailVerificationSteps = loginSteps + [passcodeStep]
         //let emailVerificationSteps = loginSteps + [passcodeStep, healthDataStep, healthRecordsStep]
         
         let informationstep = ORKInstructionStep(identifier: "info")


### PR DESCRIPTION
This PR disables background sync of HealthKit data. It doesn't appear to be necessary for the project at the moment and seems to have been causing issues when testing @blynnythepooh 